### PR TITLE
Reference binding to set Behavior BindingContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 ## EventToCommandBehavior is not working in CommunityToolkit.Maui NuGet package v10
 
 Sample project to simulate the issue https://github.com/CommunityToolkit/Maui/issues/2391
+
+As described in the Toolkit's [v10 release notes](https://github.com/CommunityToolkit/Maui/releases/tag/10.0.0), to address the breaking change with Behavior's BindingContext, it is now explicitly set on the `EventToCommandBehavior` node using the `Reference` binding workaround.
+
+```xml
+<mct:EventToCommandBehavior
+    BindingContext="{Binding BindingContext, Source={x:Reference hwv}, x:DataType=HybridWebView}"
+    Command="{Binding ShowMessageCommand}"
+    EventArgsConverter="{StaticResource ArgsConverter}"
+    EventName="RawMessageReceived" />
+```

--- a/src/MauiApp1/MauiApp1.csproj
+++ b/src/MauiApp1/MauiApp1.csproj
@@ -19,6 +19,7 @@
         <RootNamespace>MauiApp1</RootNamespace>
         <WindowsPackageType>None</WindowsPackageType>
         <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+        <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
         <!-- Display name -->
         <ApplicationTitle>MauiApp1</ApplicationTitle>
@@ -64,7 +65,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.*" Condition="'$(Configuration)' == 'Debug'" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-        <PackageReference Include="CommunityToolkit.Maui" Version="9.*" />
+        <PackageReference Include="CommunityToolkit.Maui" Version="10.*" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
     </ItemGroup>
 

--- a/src/MauiApp1/Views/MainPage.xaml
+++ b/src/MauiApp1/Views/MainPage.xaml
@@ -71,6 +71,7 @@
                                           Tablet=0}">
                     <HybridWebView.Behaviors>
                         <mct:EventToCommandBehavior
+                            BindingContext="{Binding BindingContext, Source={x:Reference hwv}, x:DataType=HybridWebView}"
                             Command="{Binding ShowMessageCommand}"
                             EventArgsConverter="{StaticResource ArgsConverter}"
                             EventName="RawMessageReceived" />


### PR DESCRIPTION
As described in the CommunityToolkit.Maui [v10 release notes](https://github.com/CommunityToolkit/Maui/releases/tag/10.0.0), to address the breaking change with Behavior's BindingContext, it is now explicitly set on the `EventToCommandBehavior` node using the `Reference` binding workaround.

```xml
<mct:EventToCommandBehavior
    BindingContext="{Binding BindingContext, Source={x:Reference hwv}, x:DataType=HybridWebView}"
    Command="{Binding ShowMessageCommand}"
    EventArgsConverter="{StaticResource ArgsConverter}"
    EventName="RawMessageReceived" />